### PR TITLE
allow running concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - reject failing commands
   - hide test plugins
 * Parallel run:
-  `npx cucumber-js test --parallel 2`
+  - allow cucumber parallel jobs: `npx cucumber-js test --parallel 2`
+  - always create new Chome working directory (user name and process ID dependent)
 
 ## Version 0.1.0 - 2023-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Plugins:
   - reject failing commands
   - hide test plugins
+* Parallel run
 
 ## Version 0.1.0 - 2023-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Plugins:
   - reject failing commands
   - hide test plugins
-* Parallel run:
+* Concurrency:
   - allow cucumber parallel jobs: `npx cucumber-js test --parallel 2`
   - always create new Chome working directory (user name and process ID dependent)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Plugins:
   - reject failing commands
   - hide test plugins
-* Parallel run
+* Parallel run:
+  `npx cucumber-js test --parallel 2`
 
 ## Version 0.1.0 - 2023-07-10
 

--- a/bin/cds-add-cucumber.js
+++ b/bin/cds-add-cucumber.js
@@ -12,10 +12,10 @@ if(!createBookshopFirstFeatureFile()) {
 
 function createCucumberConfiguration() {
   const content = `default:
-    publishQuiet: true
-    requireModule:
-      - "${getModuleName()}"
-  `
+  publishQuiet: true
+  requireModule:
+    - "${getModuleName()}"
+`
   const file = 'cucumber.yml';
 
   createFileIfMissing(file, content);

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -79,7 +79,7 @@ File: ./.vscode/launch.json
 ```
 
 Description of the parameters:
-- port - browser debugger port to attach to. By default it is 9222, but you can change it via the enviromnent variable [BROWSER\_DEBUGGING\_PORT](ENV.md#browser_debugging_port).
+- port - browser debugger port to attach to, configurable via enviromnent variable [BROWSER\_DEBUGGING\_PORT](ENV.md#browser_debugging_port).
 - webRoot - webserver root directory containing root folder webpages
 - urlFilter - filter to help locating the webpage to attach to.
 The port 4004 is the default port of the CDS Server when running standalone.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -119,8 +119,6 @@ Specifies the path to the steps-library (browser.js) to be loaded during UI debu
 
 Specifies the remote debugging port of the browser. It is used when debugging the SAP UI5 code.
 
-* default value: 9222
-
 ### CDS\_CUCUMBER\_WAIT\_DEBUGGER
 
 Forces the initialization process to wait until the debugger is attached. This happens right after the steps-library (browser.js) is loaded in the browser.

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -12,7 +12,7 @@ class Controller {
   }
 
   async initDriver() {
-    let tmpDir = `${os.tmpdir()||'/tmp'}/cds-cucumber-${os.userInfo().username}`;
+    let tmpDir = `${os.tmpdir()||'/tmp'}/cds-cucumber-${os.userInfo().username}/${process.pid}`;
     if (!fs.existsSync(tmpDir)) {
       console.log('Created temporary directory:', tmpDir);
       fs.mkdirSync(tmpDir, { recursive: true });
@@ -20,13 +20,15 @@ class Controller {
     process.env.TMPDIR = tmpDir;
     let width = 1920;
     let height = 1080;
-    this.remoteDebuggingPort = env.BROWSER_DEBUGGING_PORT || 9222;
     let options = new chrome.Options()
             .windowSize({ width, height })
             .addArguments('--user-data-dir='+tmpDir)
             .addArguments('--no-sandbox')
-            .addArguments('--disable-dev-shm-usage')
-            .addArguments(`--remote-debugging-port=${this.remoteDebuggingPort}`);
+            .addArguments('--disable-dev-shm-usage');
+    if(env.BROWSER_DEBUGGING_PORT) {
+      this.remoteDebuggingPort = env.BROWSER_DEBUGGING_PORT;
+      options.addArguments(`--remote-debugging-port=${this.remoteDebuggingPort}`);
+    }
     if(env.SHOW_BROWSER!=="1")
       options=options.headless();
     this.driver = await new Builder()
@@ -139,6 +141,8 @@ class Controller {
   async waitDebuggerToAttach(seconds=60) {
     process.stdout.write(`\nImported library: ${this.process.libUrl}`);
     process.stdout.write(`\nYou can add breakpoints in file: ${this.process.libFile}`);
+    if(!this.remoteDebuggingPort)
+      throw Error('Remote debugging port not set (see BROWSER_DEBUGGING_PORT)!');
     process.stdout.write(`\nYou can attach debugger to port ${this.remoteDebuggingPort}...\n`);
     for(let loops=seconds; loops>0; loops--) {
       let rc = await this.driver.executeScript('try { return __jsDebugIsReady;}catch(e){return false;}');

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,6 +1,8 @@
 const { env } = require('process');
 const { Builder, By } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
+const fs = require('node:fs');
+const os = require('node:os');
 
 class Controller {
 
@@ -10,11 +12,18 @@ class Controller {
   }
 
   async initDriver() {
+    let tmpDir = `${os.tmpdir()||'/tmp'}/cds-cucumber-${os.userInfo().username}`;
+    if (!fs.existsSync(tmpDir)) {
+      console.log('Created temporary directory:', tmpDir);
+      fs.mkdirSync(tmpDir, { recursive: true });
+    }
+    process.env.TMPDIR = tmpDir;
     let width = 1920;
     let height = 1080;
     this.remoteDebuggingPort = env.BROWSER_DEBUGGING_PORT || 9222;
     let options = new chrome.Options()
             .windowSize({ width, height })
+            .addArguments('--user-data-dir='+tmpDir)
             .addArguments('--no-sandbox')
             .addArguments('--disable-dev-shm-usage')
             .addArguments(`--remote-debugging-port=${this.remoteDebuggingPort}`);

--- a/test/bin/testBookshopDebug.sh
+++ b/test/bin/testBookshopDebug.sh
@@ -8,6 +8,7 @@ export CDS_COMMAND_ARG1="--with-mocks"
 export CDS_COMMAND_ARG2="--in-memory?"
 
 export CDS_CUCUMBER_DEBUG=1
+export BROWSER_DEBUGGING_PORT=9222
 #export SHOW_BROWSER=1
 export CDS_SERVICE_PORT=4004
 #export CDS_CUCUMBER_LIB_FILE_NAME="browser.js"

--- a/test/bin/testGettingStartedReuseUI5LocalBuild.sh
+++ b/test/bin/testGettingStartedReuseUI5LocalBuild.sh
@@ -67,4 +67,5 @@ else
   npx cds-add-cucumber-plugin -p local-ui5-build -f app/index.html
 fi
 
-npx cucumber-js test
+cp test/features/bookshop.feature test/features/bookshop1.feature
+npx cucumber-js test --parallel 2


### PR DESCRIPTION
Enable running cuncurrenlty with different OS-users,
fix running cucumber tests in parallel: npx cucumber-js test --parallel (number of parallel jobs)
* create temp directory for chrome user data - user name and process ID dependent directory name:
/tmp/cds-cucumber-{username}/{process.pid}
* set remote debugging port only when requested