### PR TITLE
Fix: @cap-js-community/odata-v2-adapter Error: no such directory

### DIFF
--- a/lib/startProcess.js
+++ b/lib/startProcess.js
@@ -44,9 +44,10 @@ async function startProcess(params={}) {
     if(!env.CDS_CONFIG)
       options.env.CDS_CONFIG=`{"preview": {"ui5": { "host": "/" } } }`;
   params=Object.assign(params, createWorkingDirectory());
-  if(isUnixOS)
+  if(isUnixOS) {
     options.env.HOME=params.workingDirectory;
-  else
+    options.env.TMP=params.workingDirectory;
+  } else
     options.env.USERPROFILE=params.workingDirectory;
   let libInfo = {};
   if(env.CDS_CUCUMBER_DEBUG==='1')


### PR DESCRIPTION
Set environment variable TMP used by @cap-js-community/odata-v2-adapter to cache models

Fix #215 