### PR TITLE
Fix: @cap-js-community/odata-v2-adapter Error: no such directory

### DIFF
--- a/lib/startProcess.js
+++ b/lib/startProcess.js
@@ -47,6 +47,8 @@ async function startProcess(params={}) {
   if(isUnixOS) {
     options.env.HOME=params.workingDirectory;
     options.env.TMP=params.workingDirectory;
+    options.env.TEMP=params.workingDirectory;
+    options.env.TMPDIR=params.workingDirectory;
   } else
     options.env.USERPROFILE=params.workingDirectory;
   let libInfo = {};


### PR DESCRIPTION
Set environment variables TEMP and TMPDIR used by @cap-js-community/odata-v2-adapter to cache models

#215