### PR TITLE
chore: write permission for workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
 
   publish-npm:


### PR DESCRIPTION
We now enforce a default 'read' permission across the org. This workflow needs more and must be explicit about it.